### PR TITLE
Add support for 1.8 stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 8. Next in **Specify stack details** page
     1. choose a name for your stack e.g `kubeflow`
     2. choose key-pair from dropdown to allow SSH (key must be created before template. You can create one in EC2 service > key pairs > create)
+    3. Fill the `KubeflowDashboardPassword` field
 9. Next in **Configure stack options** you don't need to configure something
 10. Make sure all your settings are correct in the last page and deploy the stack
 11. Wait until the stack is in `CREATE_COMPLETE` state

--- a/cf_kubeflow_single_instance.yaml
+++ b/cf_kubeflow_single_instance.yaml
@@ -1,16 +1,31 @@
 AWSTemplateFormatVersion: 2010-09-09
 Mappings:
   KubernetesVersionMap:
+    1.8-stable:
+      kubernetesVersion: "1.26"
     1.7-stable:
       kubernetesVersion: "1.24"
     1.6-stable:
       kubernetesVersion: "1.22"
     latest-stable:
-      kubernetesVersion: "1.25"
+      kubernetesVersion: "1.26"
     latest-beta:
-      kubernetesVersion: "1.25"
+      kubernetesVersion: "1.26"
     latest-edge:
-      kubernetesVersion: "1.25"
+      kubernetesVersion: "1.26"
+  JujuVersionMap:
+    1.8-stable:
+      jujuVersion: "3.1"
+    1.7-stable:
+      jujuVersion: "2.9"
+    1.6-stable:
+      jujuVersion: "2.9"
+    latest-stable:
+      jujuVersion: "3.1"
+    latest-beta:
+      jujuVersion: "3.1"
+    latest-edge:
+      jujuVersion: "3.1"
   RegionMap:
     eu-central-1:
       AMI: ami-xxxxxxxxxxxxxxxxx
@@ -76,8 +91,9 @@ Parameters:
     Description: Size of the (unencripted DeleteOnTermination) gp2 volume attatched to the instance
   KubeflowVersion:
     Type: String
-    Default: 1.7-stable
+    Default: 1.8-stable
     AllowedValues:
+      - 1.8-stable
       - 1.7-stable
       - 1.6-stable
       - latest-stable
@@ -124,18 +140,21 @@ Resources:
             apt update
             apt -y upgrade
             for snap in juju-wait charmcraft; do sudo snap install $snap --classic; done
-            sudo snap install juju --classic --channel=2.9/stable
+            sudo snap install juju --classic --channel=${jujuVersion}/stable
             snap install microk8s --classic --channel=${kubernetesVersion}/stable
             sudo snap refresh charmcraft --channel latest/candidate
             usermod -a -G microk8s ubuntu
             mkdir /home/ubuntu/.kube
+            mkdir -p /home/ubuntu/.local/share
             chown -f -R ubuntu /home/ubuntu/.kube
+            chown -f -R ubuntu /home/ubuntu/.local/share
 
             microk8s enable dns storage metallb:"10.64.140.43-10.64.140.49,192.168.0.105-192.168.0.111"
-            sleep 120
+            sleep 60
             microk8s.kubectl wait --for=condition=available -nkube-system deployment/coredns deployment/hostpath-provisioner
             microk8s.kubectl -n kube-system rollout status ds/calico-node
 
+            su ubuntu -c 'microk8s config | juju add-k8s microk8s --client'
             su ubuntu -c 'juju bootstrap microk8s uk8s-controller'
             su ubuntu -c 'juju add-model kubeflow'
             su ubuntu -c 'juju deploy kubeflow --channel=${kubeflowVersion} --trust'
@@ -151,6 +170,7 @@ Resources:
             echo "Charmed MlFlow and Kubeflow deployed"
           - kubernetesVersion: !FindInMap [KubernetesVersionMap, !Ref KubeflowVersion, kubernetesVersion]
             kubeflowVersion: !Join [ '/', !Split [ '-', !Ref KubeflowVersion ]]
+            jujuVersion: !FindInMap [JujuVersionMap, !Ref KubeflowVersion, jujuVersion]
         BlockDeviceMappings:
           - DeviceName: "/dev/sda1"
             Ebs:

--- a/cf_kubeflow_single_instance.yaml
+++ b/cf_kubeflow_single_instance.yaml
@@ -154,8 +154,8 @@ Resources:
             microk8s.kubectl wait --for=condition=available -nkube-system deployment/coredns deployment/hostpath-provisioner
             microk8s.kubectl -n kube-system rollout status ds/calico-node
 
-            su ubuntu -c 'microk8s config | juju add-k8s microk8s --client'
-            su ubuntu -c 'juju bootstrap microk8s uk8s-controller'
+            su ubuntu -c 'microk8s config | juju add-k8s my-k8s --client'
+            su ubuntu -c 'juju bootstrap my-k8s uk8s-controller'
             su ubuntu -c 'juju add-model kubeflow'
             su ubuntu -c 'juju deploy kubeflow --channel=${kubeflowVersion} --trust'
 


### PR DESCRIPTION
**Added**:
- support for 1.8 stable 

**Changes**:
- Set juju version based of the chosen Kubeflow version
- Add fix for juju 3.1 setup 
- Change Kubernetes versions for beta nad edge 

**Tested**: 
- tested al lversions on my AWS account

**How to review**:
- You can try to deploy the stack based on the steps in REAMDE.md